### PR TITLE
remoting: improve the loading timeout

### DIFF
--- a/ggml/src/ggml-remotingbackend/shared/apir_backend.h
+++ b/ggml/src/ggml-remotingbackend/shared/apir_backend.h
@@ -90,13 +90,17 @@ static inline void start_timer(struct timer_data *timer) {
   timer->start = (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
 }
 
-static inline void stop_timer(struct timer_data *timer) {
+// returns the duration in ns
+static inline long long stop_timer(struct timer_data *timer) {
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);  // Use CLOCK_MONOTONIC for elapsed time
   long long timer_end = (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
 
-  timer->total += (timer_end - timer->start);
+  long long duration = (timer_end - timer->start);
+  timer->total += duration;
   timer->count += 1;
+
+  return duration;
 }
 
 static inline void show_timer(struct timer_data *timer) {

--- a/ggml/src/ggml-remotingbackend/shared/apir_backend.h
+++ b/ggml/src/ggml-remotingbackend/shared/apir_backend.h
@@ -83,6 +83,9 @@ struct timer_data {
 extern struct timer_data graph_compute_timer;
 extern struct timer_data get_tensor_timer;
 extern struct timer_data set_tensor_timer;
+extern struct timer_data wait_host_reply_timer;
+extern struct timer_data get_tensor_from_ptr_timer;
+extern struct timer_data set_tensor_from_ptr_timer;
 
 static inline void start_timer(struct timer_data *timer) {
   struct timespec ts;
@@ -108,8 +111,8 @@ static inline void show_timer(struct timer_data *timer) {
   double itl = ms/timer->count;
   double speed = 1/itl * 1000;
 
-  INFO("%14s [%9.0f] ms for %4ld invocations | ITL %2.2f ms | throughput = %4.2f t/s",
-       timer->name, ms, timer->count, itl, speed);
+  INFO("%15s [%9.0f] ms for %4ld invocations | ITL %2.2f ms | throughput = %4.2f t/s (%4.2f ms/call)",
+       timer->name, ms, timer->count, itl, speed, ms/timer->count);
 }
 
 static const char *apir_backend_initialize_error(int code) {

--- a/ggml/src/ggml-remotingfrontend/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-remotingfrontend/ggml-backend-reg.cpp
@@ -121,6 +121,12 @@ static void showTime() {
   show_timer(&graph_compute_timer);
   show_timer(&get_tensor_timer);
   show_timer(&set_tensor_timer);
+  show_timer(&wait_host_reply_timer);
+
+  if (get_tensor_from_ptr_timer.count) {
+    show_timer(&get_tensor_from_ptr_timer);
+    show_timer(&set_tensor_from_ptr_timer);
+  }
 }
 
 ggml_backend_reg_t ggml_backend_remoting_frontend_reg() {

--- a/ggml/src/ggml-remotingfrontend/virtgpu-utils.h
+++ b/ggml/src/ggml-remotingfrontend/virtgpu-utils.h
@@ -34,6 +34,8 @@ void breakpoint();
 #ifndef NDEBUG
 inline void
 INFO(const char *format, ...) {
+  fprintf(stderr, "INFO: ");
+
   va_list argptr;
   va_start(argptr, format);
   vfprintf(stderr, format, argptr);
@@ -48,6 +50,17 @@ INFO(...) {}
 inline void
 WARNING(const char *format, ...) {
   fprintf(stderr, "WARNING: ");
+
+  va_list argptr;
+  va_start(argptr, format);
+  vfprintf(stderr, format, argptr);
+  fprintf(stderr, "\n");
+  va_end(argptr);
+}
+
+inline void
+ERROR(const char *format, ...) {
+  fprintf(stderr, "ERROR: ");
 
   va_list argptr;
   va_start(argptr, format);

--- a/ggml/src/ggml-remotingfrontend/virtgpu.cpp
+++ b/ggml/src/ggml-remotingfrontend/virtgpu.cpp
@@ -26,6 +26,8 @@ virtgpu_ioctl_get_caps(struct virtgpu *gpu,
 static uint64_t virtgpu_ioctl_getparam(struct virtgpu *gpu, uint64_t param);
 static void virtgpu_init_renderer_info(struct virtgpu *gpu);
 
+struct timer_data wait_host_reply_timer = {0, 0, 0, "wait_host_reply"};
+
 static inline void
 virtgpu_init_shmem_blob_mem(struct virtgpu *gpu)
 {

--- a/ggml/src/ggml-remotingfrontend/virtgpu.h
+++ b/ggml/src/ggml-remotingfrontend/virtgpu.h
@@ -113,5 +113,5 @@ struct vn_cs_encoder *remote_call_prepare(
   struct virtgpu *gpu,
   int32_t cmd_type,
   int32_t cmd_flags);
-struct vn_cs_decoder *remote_call(struct virtgpu *gpu, struct vn_cs_encoder *enc, uint64_t max_ns);
+struct vn_cs_decoder *remote_call(struct virtgpu *gpu, struct vn_cs_encoder *enc, float max_wait_ms);
 int32_t remote_call_finish(struct vn_cs_encoder *enc, struct vn_cs_decoder *dec);


### PR DESCRIPTION
## Summary by Sourcery

Improve host reply timeout handling by converting to millisecond granularity, adding dedicated timers, and enhancing logging and diagnostics

Enhancements:
- Switch remote_call timeout parameter to milliseconds and use CLOCK_MONOTONIC for accurate wait loops
- Introduce wait_host_reply_timer to measure and log host reply wait durations in nanoseconds, milliseconds, or seconds
- Enhance timer utilities: make stop_timer return duration, and augment show_timer to display per-call ms metrics
- Add INFO and ERROR logging macros to virtgpu-utils for consistent log prefixing
- Register new timers (wait_host_reply_timer, get_tensor_from_ptr_timer, set_tensor_from_ptr_timer) in backend header and show them in diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging with new ERROR and improved INFO messages for better error and status reporting.
  * Added detailed timing metrics for host reply waits and tensor operations, including average milliseconds per call.

* **Improvements**
  * Increased the host reply wait timeout from 0.2 seconds to 3 seconds for more robust remote operations.
  * Improved timer accuracy and reporting, now displaying precise wait durations and averages.

* **Bug Fixes**
  * More accurate timeout handling and error reporting during remote operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->